### PR TITLE
Substitute the parameter names correctly if used multiple times

### DIFF
--- a/src/preprocess.ts
+++ b/src/preprocess.ts
@@ -43,7 +43,10 @@ function handleNamedParams(
 
   let mangledSQL = sql
   for (const [name, index] of paramIndices) {
-    mangledSQL = mangledSQL.replace('${' + name + '}', '$' + index)
+    mangledSQL = mangledSQL.replace(
+      new RegExp('\\$\\{' + name + '\\}', 'g'),
+      '$' + index
+    )
   }
 
   // Iterating a Map is guaranteed to yield in the insertion order

--- a/tests/integration/same-param-twice.sql
+++ b/tests/integration/same-param-twice.sql
@@ -1,0 +1,28 @@
+-- The ${min} parameter is used multiple times here. Both should be
+-- mapped to $1.
+--- setup -----------------------------------------------------------------
+
+CREATE TABLE person (
+  age integer,
+  shoe_size integer
+);
+
+--- query -----------------------------------------------------------------
+
+SELECT * FROM person
+WHERE
+    age >= ${min} AND
+    shoe_size >= ${min}
+
+--- expected row count ----------------------------------------------------
+
+many
+
+--- expected column types -------------------------------------------------
+
+age: number
+shoe_size: number
+
+--- expected param types --------------------------------------------------
+
+min: number


### PR DESCRIPTION
Fixes #2