### PR TITLE
Support View in Select Query

### DIFF
--- a/src/sql/tableColumns.sql
+++ b/src/sql/tableColumns.sql
@@ -3,7 +3,8 @@ FROM pg_catalog.pg_attribute attr
 JOIN pg_catalog.pg_class cls on attr.attrelid = cls.oid
 JOIN pg_catalog.pg_namespace nsp ON nsp.oid = cls.relnamespace
 WHERE
-    cls.relkind = 'r'
+    (cls.relkind = 'r'
+    OR cls.relkind = 'v')
     AND nsp.nspname = ${schemaName}
     AND cls.relname = ${tableName}
 ORDER BY attnum

--- a/src/sql/tableColumns.ts
+++ b/src/sql/tableColumns.ts
@@ -20,7 +20,8 @@ FROM pg_catalog.pg_attribute attr
 JOIN pg_catalog.pg_class cls on attr.attrelid = cls.oid
 JOIN pg_catalog.pg_namespace nsp ON nsp.oid = cls.relnamespace
 WHERE
-    cls.relkind = 'r'
+    (cls.relkind = 'r'
+    OR cls.relkind = 'v')
     AND nsp.nspname = $1
     AND cls.relname = $2
 ORDER BY attnum

--- a/tests/integration/view.sql
+++ b/tests/integration/view.sql
@@ -1,0 +1,23 @@
+--- setup -----------------------------------------------------------------
+
+CREATE TABLE person (
+  name varchar(255) NOT NULL,
+  age integer
+);
+
+CREATE VIEW view_person AS SELECT name FROM person
+
+--- query -----------------------------------------------------------------
+
+SELECT * FROM view_person
+
+--- expected row count ----------------------------------------------------
+
+many
+
+--- expected column types -------------------------------------------------
+
+name: string | null
+
+--- expected param types --------------------------------------------------
+


### PR DESCRIPTION
Before this update sqltyper has this warning when using View inside a Select query

```
WARNING: The internal SQL parser failed to parse the SQL statement.

Parse error: No such table: view_name

Due to the problems listed above, the inferred types may be inaccurate with respect to nullability.

Please open an issue on https://github.com/akheron/sqltyper.
```

This PR is too add supporting View in Select query.

P/s: test is failed, but it seems test failed from the last commit: [Using Postgres.js](https://github.com/akheron/sqltyper/commit/2b882969554877e649437ee1906678b8234cdaf9)