### PR TITLE
Ignore dropped columns

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -60,12 +60,14 @@ export function schemaClient(postgresClient: postgres.Sql<{}>): SchemaClient {
     }
     return Either.right({
       name: tableName,
-      columns: result.map((col) => ({
-        hidden: col.attnum < 0,
-        name: col.attname,
-        nullable: !col.attnotnull,
-        type: col.atttypid,
-      })),
+      columns: result
+        .filter((col) => col.attisdropped === false)
+        .map((col) => ({
+          hidden: col.attnum < 0,
+          name: col.attname,
+          nullable: !col.attnotnull,
+          type: col.atttypid,
+        })),
     })
   }
 

--- a/src/sql/tableColumns.sql
+++ b/src/sql/tableColumns.sql
@@ -1,4 +1,4 @@
-SELECT attnum, attname, atttypid, attnotnull
+SELECT attnum, attname, atttypid, attnotnull, attisdropped
 FROM pg_catalog.pg_attribute attr
 JOIN pg_catalog.pg_class cls on attr.attrelid = cls.oid
 JOIN pg_catalog.pg_namespace nsp ON nsp.oid = cls.relnamespace

--- a/src/sql/tableColumns.ts
+++ b/src/sql/tableColumns.ts
@@ -12,10 +12,11 @@ export async function tableColumns(
     attname: string
     atttypid: number
     attnotnull: boolean
+    attisdropped: boolean
   }>
 > {
   const result = await sql.unsafe(
-    `SELECT attnum, attname, atttypid, attnotnull
+    `SELECT attnum, attname, atttypid, attnotnull, attisdropped
 FROM pg_catalog.pg_attribute attr
 JOIN pg_catalog.pg_class cls on attr.attrelid = cls.oid
 JOIN pg_catalog.pg_namespace nsp ON nsp.oid = cls.relnamespace


### PR DESCRIPTION
Hi, 

First of all, thanks for this repo, it's been great so far! We're running into a few issues though, but I plan to fix them one by one. This is the first thing we encountered: The DB my team inherited has dropped columns. They are reported by Postgres, with a weird name like ".......pg.dropped8........". I looked online and found this post:

[https://www.postgresql.org/message-id/Pine.LNX.4.44.0309052224030.1173-100000%40peter.localdomain]()

So I added the attrisdropped filter here. I think just flat out filtering them here is the best option, I don't think sqltyper needs these columns anywhere else.

Simon