### PR TITLE
add support for pg-promise target

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ npm install --save-dev sqltyper
 ```
 
 The generated TypeScript code uses [node-postgres], [postgres.js], or
-[pg-promise] to execute the queries, so either `pg` or `postgres` is a required
-runtime dependency:
+[pg-promise] to execute the queries, so either `pg`, `postgres`, or `pg-promise`
+is a required runtime dependency:
 
 ```
 npm install --save pg
 # or
 npm install --save postgres@beta
+# or
+npm install --save pg-promise
 ```
 
 At the time of writing, you need to install the `@beta` verson of postgres.js to

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ safe to use it with any query.
 npm install --save-dev sqltyper
 ```
 
-The generated TypeScript code uses [node-postgres] or [postgres.js] to execute
-the queries, so either `pg` or `postgres` is a required runtime dependency:
+The generated TypeScript code uses [node-postgres], [postgres.js], or
+[pg-promise] to execute the queries, so either `pg` or `postgres` is a required
+runtime dependency:
 
 ```
 npm install --save pg
@@ -192,8 +193,8 @@ Watch files and run the conversion when something changes. Default: `false`.
 
 `--target`, `-t`
 
-Whether to generate code for `pg` ([node-postgres]) or `postgres`
-([postgres.js]). Default: `pg`.
+Whether to generate code for `pg` ([node-postgres]), `postgres` ([postgres.js]),
+or `pg-promise` ([pg-promise]). Default: `pg`.
 
 `--module`, `-m`
 
@@ -277,4 +278,5 @@ select the newest version tag, adjust the description as needed.
 
 [node-postgres]: https://node-postgres.com/
 [postgres.js]: https://github.com/porsager/postgres
+[pg-promise]: http://vitaly-t.github.io/pg-promise/
 [sqlτyped]: https://github.com/jonifreeman/sqltyped

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,7 +148,8 @@ function parseArgs() {
     })
     .option('module', {
       alias: 'm',
-      description: 'Where to import node-postgres or postgres.js from.',
+      description:
+        'Where to import node-postgres, postgres.js, or pg-promise from.',
       type: 'string',
     })
     .option('check', {

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -163,7 +163,7 @@ export async function ${funcName}(
     return `\
 ${topComment(sourceFileName)}
 
-import pgp from '${module}'
+import * as pgp from '${module}'
 
 export async function ${funcName}(
   client: pgp.IDatabase<any, any>${params}


### PR DESCRIPTION
This PR adds basic support for generating with `pg-promise` as the target. Despite being backed by `pg`, the APIs and types are slightly different. For example, there is no `ClientBase` or `Pool` types; all query functions are located directly on the database instance type itself.

In order to test this, I ran it against some SQL queries in an (unfortunately private) repo I work in and have validated that it produces usable output. I'm happy to add additional tests if necessary or desired.