### PR TITLE
Support IN ('a', 'b')

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -114,13 +114,13 @@ export namespace Expression {
     kind: 'InOp'
     lhs: Expression
     op: 'IN' | 'NOT IN'
-    subquery: Select
+    subquery: Select | Expression[]
   }
 
   export function createInOp(
     lhs: Expression,
     op: 'IN' | 'NOT IN',
-    subquery: Select
+    subquery: Select | Expression[]
   ): InOp {
     return { kind: 'InOp', lhs, op, subquery }
   }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -110,19 +110,32 @@ export namespace Expression {
     return { kind: 'ExistsOp', subquery }
   }
 
+  export type InSubquery = { kind: 'InSubquery'; subquery: Select }
+
+  export function createInSubquery(subquery: Select): InSubquery {
+    return { kind: 'InSubquery', subquery }
+  }
+
+  export type InExprList = { kind: 'InExprList'; exprList: Expression[] }
+
+  export function createInExprList(exprList: Expression[]): InExprList {
+    return { kind: 'InExprList', exprList }
+  }
+
+  export type InRhs = InSubquery | InExprList
   export type InOp = {
     kind: 'InOp'
     lhs: Expression
     op: 'IN' | 'NOT IN'
-    subquery: Select | Expression[]
+    rhs: InRhs
   }
 
   export function createInOp(
     lhs: Expression,
     op: 'IN' | 'NOT IN',
-    subquery: Select | Expression[]
+    rhs: InRhs
   ): InOp {
-    return { kind: 'InOp', lhs, op, subquery }
+    return { kind: 'InOp', lhs, op, rhs }
   }
 
   export type FunctionCall = {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -282,7 +282,7 @@ namespace OtherExprRhs {
   export type In = {
     kind: 'InExprRhs'
     op: 'IN' | 'NOT IN'
-    rhs: Select
+    rhs: Select | Expression[]
   }
   const in_: Parser<In> = seq(
     attempt(
@@ -291,7 +291,12 @@ namespace OtherExprRhs {
         seqConst('NOT IN', reservedWord('NOT'), reservedWord('IN'))
       )
     ),
-    parenthesized(lazy(() => select))
+    parenthesized(
+      oneOf<Select | Expression[]>(
+        lazy(() => select),
+        sepBy1(symbol(','), constantExpr)
+      )
+    )
   )((op, rhs) => ({ kind: 'InExprRhs', op, rhs }))
 
   export type Ternary = {

--- a/tests/integration/in-scalars.sql
+++ b/tests/integration/in-scalars.sql
@@ -1,16 +1,19 @@
--- Array columns are nullable if they don't have the NOT NULL
--- constraint. Furthermore, their items are always nullable.
 --- setup -----------------------------------------------------------------
 
-CREATE TABLE person (
-  child_ages integer[],
-  parent_ages integer[] NOT NULL
+CREATE TABLE test (
+  foo integer NOT NULL,
+  bar integer,
+  baz integer
 );
 
 --- query -----------------------------------------------------------------
 
-SELECT child_ages, parent_ages
-FROM person
+SELECT
+    1 IN (foo, :param) AS a,
+    1 IN (foo, bar) AS b,
+    1 + NULL IN (1, 2, 3) AS c,
+    1 IN ((SELECT foo FROM test LIMIT 1), 1, 2) AS d
+FROM test
 
 --- expected row count ----------------------------------------------------
 
@@ -18,7 +21,11 @@ many
 
 --- expected column types -------------------------------------------------
 
-child_ages: Array<number | null> | null
-parent_ages: Array<number | null>
+a: boolean
+b: boolean | null
+c: boolean | null
+d: boolean
 
 --- expected param types --------------------------------------------------
+
+param: number


### PR DESCRIPTION
`IN` supports selecting from a list of values: https://www.postgresqltutorial.com/postgresql-in/

Prevously, IN only supposed nested select statements. This updates the Parser and AST to support nested expression lists