### PR TITLE
Support duplicate columns

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,6 +1,5 @@
 import * as path from 'path'
 
-import * as Either from 'fp-ts/lib/Either'
 import * as Task from 'fp-ts/lib/Task'
 import { pipe } from 'fp-ts/lib/function'
 
@@ -15,30 +14,6 @@ export const codegenTargets: ReadonlyArray<CodegenTarget> = [
   'postgres',
   'pg-promise',
 ]
-
-////////////////////////////////////////////////////////////////////////
-
-export function validateStatement(
-  stmt: StatementDescription
-): Either.Either<string, StatementDescription> {
-  const columnNames: Set<string> = new Set()
-  const conflicts: Set<string> = new Set()
-
-  stmt.columns.forEach(({ name }) => {
-    if (columnNames.has(name)) {
-      conflicts.add(name)
-    } else {
-      columnNames.add(name)
-    }
-  })
-
-  if (conflicts.size) {
-    const dup = [...conflicts.values()].sort().join(', ')
-    return Either.left(`Duplicate output columns: ${dup}`)
-  }
-
-  return Either.right(stmt)
-}
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -91,6 +91,18 @@ export function inferColumnNullability(
 ): InferM.InferM<StatementDescription> {
   return pipe(
     getOutputColumns(client, [], paramNullability, tree),
+    InferM.map((outputColumns) => {
+      const columnNames: Set<string> = new Set()
+      return outputColumns
+        .filter((outputColumn) => {
+          if (columnNames.has(outputColumn.name)) {
+            return false
+          }
+          columnNames.add(outputColumn.name)
+          return true
+        })
+        .sort((a, b) => a.name.localeCompare(b.name))
+    }),
     InferM.chain((outputColumns) =>
       InferM.fromEither(applyColumnNullability(statement, outputColumns))
     )


### PR DESCRIPTION
Currently, duplicate columns will throw an error. However, it's possible (if not common) for there to be duplicate columns in the event of a join. This supports those duplicate columns by removing the duplicates from the query analyzer and the parser, and then sorting the list of columns to ensure that they will match correctly.