### PR TITLE
Fix bug where oneOf would not retry other paths because offset would change

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -797,9 +797,7 @@ export namespace WithQuery {
 
 // ---------------------------------------------------------------------
 
-export type Statement = [WithQuery[], Select | Insert | Update] | Delete
-
-export type AST = Statement
+export type AST = [WithQuery[], Select | Insert | Update] | Delete
 
 export function walk<T>(
   ast: AST,

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -104,7 +104,7 @@ function getOutputColumns(
   tree: ast.AST
 ): InferM.InferM<VirtualField[]> {
   return ast.walk(tree, {
-    select: ({ ctes, body, setOps }) =>
+    select: ({ body, setOps }, ctes) =>
       pipe(
         combineVirtualTables(
           outsideCTEs,
@@ -134,7 +134,7 @@ function getOutputColumns(
           )
         )
       ),
-    update: ({ ctes, table, as, from, where, returning }) =>
+    update: ({ table, as, from, where, returning }, ctes) =>
       pipe(
         combineVirtualTables(
           outsideCTEs,
@@ -702,7 +702,7 @@ function inferExpressionNullability(
     // the inside depends on the inside select list expression
     arraySubQuery: ({ subquery }) =>
       pipe(
-        getOutputColumns(client, outsideCTEs, paramNullability, subquery),
+        getOutputColumns(client, outsideCTEs, paramNullability, [[], subquery]),
         InferM.chain((columns) => {
           if (columns.length != 1)
             return TaskEither.left('subquery must return only one column')

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -31,7 +31,6 @@ import {
   SelectBody,
   SelectOp,
   SelectListItem,
-  Statement,
   TableExpression,
   TableRef,
   UpdateAssignment,

--- a/src/typed-parser/index.ts
+++ b/src/typed-parser/index.ts
@@ -376,7 +376,7 @@ export function oneOf<A>(...parsers: Parser<A>[]): Parser<A> {
     const errors = []
     const originalOffset = context.offset
     for (const parser of parsers) {
-      const result = parser(source, context)
+      const result = attempt(parser)(source, context)
       if (!(result instanceof AbstractFailure)) {
         return result
       }

--- a/src/typed-parser/index.ts
+++ b/src/typed-parser/index.ts
@@ -376,7 +376,7 @@ export function oneOf<A>(...parsers: Parser<A>[]): Parser<A> {
     const errors = []
     const originalOffset = context.offset
     for (const parser of parsers) {
-      const result = attempt(parser)(source, context)
+      const result = parser(source, context)
       if (!(result instanceof AbstractFailure)) {
         return result
       }


### PR DESCRIPTION
Previously, in some oneOf cases, like `parser::statementParser`, we would never try other branches because the offset would change, and we'd consider that an error. In order to alleviate this, I've wrapped the parser in an `attempt` which will reset the offset before trying the next branch, which allows for other branches to potentially succeed where they wouldn't before