### PR TITLE
Allow UPDATE alias to not have AS

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -795,7 +795,7 @@ const updateTable: Parser<TableRef> = seq2(reservedWord('UPDATE'), tableRef)
 const update: Parser<Update> = seq(
   optional(withQueries),
   updateTable,
-  optional(reqAs),
+  optional(as),
   updateAssignments,
   optional(from),
   optional(where),


### PR DESCRIPTION
UPDATE allows for table aliases but does not require `AS`. This changes the parser to not require `AS`.