### PR TITLE
Fix INSERT row count when there's no RETURNING

### DIFF
--- a/src/infer.ts
+++ b/src/infer.ts
@@ -1051,20 +1051,18 @@ function inferRowCount(
     },
 
     insert: ({ valuesOrSelect, returning }) =>
-      valuesOrSelect.kind === 'Select'
-        ? 'many'
-        : ast.Values.walk(valuesOrSelect, {
-            // INSERT INTO xxx DEFAULT VALUES always creates a single row
-            defaultValues: () => 'one',
-            exprValues: (exprValues) =>
-              returning.length
-                ? // Check the length of the VALUES expression list
-                  exprValues.valuesList.length === 1
-                  ? 'one'
-                  : 'many'
-                : // No RETURNING, no output
-                  'zero',
-          }),
+      returning.length > 0
+        ? valuesOrSelect.kind === 'Select'
+          ? 'many'
+          : ast.Values.walk(valuesOrSelect, {
+              // INSERT INTO xxx DEFAULT VALUES always creates a single row
+              defaultValues: () => 'one',
+              exprValues: (exprValues) =>
+                // Check the length of the VALUES expression list
+                exprValues.valuesList.length === 1 ? 'one' : 'many',
+            })
+        : // No RETURNING, no output
+          'zero',
 
     update: ({ returning }) =>
       returning.length

--- a/tests/integration/delete.sql
+++ b/tests/integration/delete.sql
@@ -1,0 +1,22 @@
+--- setup -----------------------------------------------------------------
+
+CREATE TABLE person (
+  id serial PRIMARY KEY,
+  name varchar(255) NOT NULL,
+  age integer
+);
+
+--- query -----------------------------------------------------------------
+
+DELETE FROM person WHERE name = ${name} AND age = ${age};
+
+--- expected row count ----------------------------------------------------
+
+zero
+
+--- expected column types ----------------------------------------------------
+
+--- expected param types --------------------------------------------------
+
+name: string
+age: number

--- a/tests/integration/insert.sql
+++ b/tests/integration/insert.sql
@@ -1,0 +1,22 @@
+--- setup -----------------------------------------------------------------
+
+CREATE TABLE person (
+  id serial PRIMARY KEY,
+  name varchar(255) NOT NULL,
+  age integer
+);
+
+--- query -----------------------------------------------------------------
+
+INSERT INTO person (name, age) VALUES (${name}, ${age});
+
+--- expected row count ----------------------------------------------------
+
+zero
+
+--- expected column types ----------------------------------------------------
+
+--- expected param types --------------------------------------------------
+
+name: string
+age: number | null

--- a/tests/integration/update.sql
+++ b/tests/integration/update.sql
@@ -1,0 +1,22 @@
+--- setup -----------------------------------------------------------------
+
+CREATE TABLE person (
+  id serial PRIMARY KEY,
+  name varchar(255) NOT NULL,
+  age integer
+);
+
+--- query -----------------------------------------------------------------
+
+UPDATE person SET name = ${name}, age = ${age};
+
+--- expected row count ----------------------------------------------------
+
+zero
+
+--- expected column types ----------------------------------------------------
+
+--- expected param types --------------------------------------------------
+
+name: string
+age: number | null


### PR DESCRIPTION
While at it, add tests for `UPDATE` and `DELETE` without `RETURNING`, too.